### PR TITLE
Fix test type imports for SimpleConstraint

### DIFF
--- a/test/unit/problem-solver.spec.ts
+++ b/test/unit/problem-solver.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
-import { DancingLinks, SimpleConstraint } from '../../index.js'
+import { DancingLinks } from '../../index.js'
+import type { SimpleConstraint } from '../../index.js'
 
 describe('ProblemSolver', function () {
   it('should solve a simple exact cover problem', function () {


### PR DESCRIPTION
## Summary

Fix test imports to use type-only imports for TypeScript interfaces that don't exist in JavaScript runtime.

## Problem

After updating Mocha to 11.7.5, tests were failing with:
```
SyntaxError: The requested module '../../index.js' does not provide an export named 'SimpleConstraint'
```

This occurred because `SimpleConstraint` is a TypeScript interface (type-only) that doesn't exist in the compiled JavaScript. When importing from the built JS files, the interface isn't available.

## Solution

Change the import to use TypeScript's `type` import syntax:
```typescript
import type { SimpleConstraint } from '../../index.js'
```

This tells TypeScript that `SimpleConstraint` is only used for type annotations and should be stripped during compilation.

## Test plan

- [x] All 48 unit tests passing
- [x] Code formatted with Prettier
- [x] Linting passes
- [x] Production build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)