### PR TITLE
fix(ci): sync npm 11 lockfile dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4132,6 +4132,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",


### PR DESCRIPTION
## What changed

- Record optional `encoding@0.1.13` and its nested `iconv-lite@0.6.3` dependency in `package-lock.json`.
- Preserve every existing dependency version and peer marker.

## Why

Node 25 ships npm 11, which validates optional transitive dependencies during `npm ci`. The existing merge-base lockfile omitted these two records, so CI stopped during dependency installation before build, lint, tests, or performance comparisons could run.

The performance workflow benchmarks the merge-base first, so this fix must land on `master` before optimization PR benchmarks can obtain a valid baseline.

## Validation

- Clean `npm ci --ignore-scripts` with Node 25.7.0 / npm 11.10.1
- Lockfile diff is limited to the two missing package records (25 added lines)
