### PR TITLE
fix(ci): publish npm releases through trusted OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,46 @@ jobs:
     needs: should-run
     uses: ./.github/workflows/build.yml
 
+  # Generate release benchmark documentation on consistent Namespace hardware.
+  # GitHub-hosted CPU performance is too variable for published comparisons.
+  benchmark-docs:
+    runs-on: namespace-profile-default
+    needs: [lint, test, build]
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          # Preserve the runtime used by the release benchmarks before OIDC
+          # publishing required the release job itself to use Node.js 24.
+          node-version: 25
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Update benchmark documentation
+        run: npm run update-benchmark-docs -- --quiet
+
+      - name: Upload benchmark documentation
+        # Pass only non-executable benchmark output into the privileged job.
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-benchmark-docs-${{ github.sha }}
+          path: README.md
+          if-no-files-found: error
+          retention-days: 1
+
   # Release only after all prerequisites complete
   release:
     # npm trusted publishing currently accepts only GitHub-hosted runners.
     runs-on: ubuntu-latest
-    needs: [lint, test, build]
+    needs: benchmark-docs
     permissions:
       contents: write
       id-token: write
@@ -41,6 +76,21 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download benchmark documentation
+        # Extract outside the checkout so the artifact cannot add package files.
+        uses: actions/download-artifact@v4
+        with:
+          name: release-benchmark-docs-${{ github.sha }}
+          path: ${{ runner.temp }}/release-benchmark-docs
+
+      - name: Apply benchmark documentation
+        run: cp "$RUNNER_TEMP/release-benchmark-docs/README.md" README.md
+
+      - name: Verify benchmark documentation scope
+        # The trusted job consumes the Namespace result only as README data;
+        # executable release inputs must still come from the checked-out SHA.
+        run: git diff --exit-code -- . ':(exclude)README.md'
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -66,8 +116,9 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Release
-        # release-it skips its token-only npm preflight; npm publish exchanges
-        # this job's short-lived OIDC identity for registry authorization.
-        run: npm run release -- --ci --npm.skipChecks
+        # Skip release-it's token-only npm preflight and override only its
+        # benchmark hook: Namespace already generated the README, so the
+        # variable GitHub-hosted CPU must not replace those measurements.
+        run: npm run release -- --ci --npm.skipChecks --hooks.after:bump="npm run format"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,22 +28,31 @@ jobs:
 
   # Release only after all prerequisites complete
   release:
-    runs-on: namespace-profile-default
+    # npm trusted publishing currently accepts only GitHub-hosted runners.
+    runs-on: ubuntu-latest
     needs: [lint, test, build]
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 25
-          cache: 'npm'
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: Install npm with trusted publishing support
+        # Trusted publishing requires npm >=11.5.1; pin the major so a future
+        # npm release cannot silently change the privileged release toolchain.
+        run: npm install --global npm@11
 
       - name: Install dependencies
         run: npm ci
@@ -57,8 +66,8 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Release
-        run: npm run release -- --ci
+        # release-it skips its token-only npm preflight; npm publish exchanges
+        # this job's short-lived OIDC identity for registry authorization.
+        run: npm run release -- --ci --npm.skipChecks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What changed

- Generate release benchmark documentation on `namespace-profile-default` with Node 25 after lint, test, and build succeed.
- Upload only `README.md` as a SHA-scoped, one-day artifact, download it outside the checkout, and copy only that file into the release worktree.
- Run npm publishing on a supported GitHub-hosted runner with job-scoped `contents: write` and `id-token: write`.
- Use checkout/setup-node v6, Node 24, npm 11, and disable package-manager caching for the privileged publish job.
- Remove `NPM_TOKEN` and `NODE_AUTH_TOKEN` from the release environment.
- Skip release-it 19's token-based npm preflight and override its benchmark hook only in CI, because the Namespace job already generated the README. Manual releases retain the existing benchmark hook.

## Why

The failed Release run reached npm with the old automation token and was rejected with `EOTP`. npm trusted publishing authenticates `npm publish` through a short-lived OIDC identity, requires a GitHub-hosted runner and npm 11.5.1 or newer, and does not need a long-lived npm token.

The release hook also publishes fresh performance comparisons in the README. GitHub-hosted CPU performance is too variable for those measurements, so the workflow now keeps benchmark generation on the existing Namespace runner while isolating the actual OIDC publish on GitHub-hosted infrastructure.

release-it's default `npm whoami` preflight cannot observe the publish-time OIDC identity, so the workflow bypasses only that preflight. Its real versioning, changelog, commit, tag, push, GitHub release, and `npm publish` behavior remains active.

## Security boundary

- The Namespace benchmark job has only `contents: read`, with no secrets or OIDC permission.
- Only non-executable `README.md` output crosses the job boundary.
- The artifact is extracted under `RUNNER_TEMP`; the privileged job explicitly copies one expected file and verifies that no other tracked file changed.
- Package build and publishing inputs still come from the checked-out event SHA on the GitHub-hosted job.

## npm configuration required before merge

The `dancing-links` package's trusted publisher must match:

- Owner: `TimBeyer`
- Repository: `dancing-links`
- Workflow filename: `release.yml`
- Allowed action: `npm publish`
- Environment: blank

## Validation

- Parsed `.github/workflows/release.yml` as YAML and asserted the runner, permission, dependency, artifact, and token-removal contract.
- Verified Prettier formatting and `git diff --check`.
- Verified release-it 19 parses `--npm.skipChecks` and the CI-only `after:bump` hook override correctly.
- Release-it dry-runs prove CI runs formatting without rerunning benchmarks, while an ordinary/manual release retains `update-benchmark-docs`.
- Verified release-it stages the tracked README via `git add . --update`.
- Smoke-tested benchmark updater argument forwarding without generating local measurements.
- `npm test` (48 passing).
- `npm run build`.
- `npm run lint`.
- Independent workflow/release audit: no blockers.

The publish itself runs only after a push to `master`, so the final OIDC exchange is verified by the post-merge Release run.

References: [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/), [GitHub workflow artifacts](https://docs.github.com/en/actions/tutorials/store-and-share-data#passing-data-between-jobs-in-a-workflow), [release-it OIDC setup](https://github.com/release-it/release-it/blob/main/docs/npm.md#trusted-publishing-oidc).